### PR TITLE
解决微信小程序调试基础库3.4.10以上版本wx.getSystemInfoSync废弃的问题

### DIFF
--- a/components/DropDown/index.jsx
+++ b/components/DropDown/index.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useState, forwardRef, useImperativeHandle, useMemo, useRef } from 'react'
 import { View, Text } from '@tarojs/components'
 import { Layout, getRect, Absolute } from '@/duxapp'
-import { getSystemInfoSync } from '@tarojs/taro'
+import { getWindowInfo } from '@tarojs/taro'
 import { DuxuiIcon } from '../DuxuiIcon'
 import './index.scss'
 
@@ -60,7 +60,7 @@ export const DropDown = forwardRef(({
 
   const menuLayout = useCallback(layout => {
     (async () => {
-      const { windowWidth: width, windowHeight: height } = getSystemInfoSync()
+      const { windowWidth: width, windowHeight: height } = getWindowInfo()
       const newposition = { ...clickSize.current, opacity: 1 }
       // 此处需要修改
       const { left: x, top: y, width: viewWidth, height: viewHeight } = await getRect('.' + currentClass)

--- a/components/DropDown/index.rn.jsx
+++ b/components/DropDown/index.rn.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState, forwardRef, useImperativeHandle } from 'react'
 import { TouchableOpacity, View, Text, Dimensions } from 'react-native'
-import { getSystemInfoSync } from '@tarojs/taro'
+import { getWindowInfo } from '@tarojs/taro'
 import { Absolute } from '@/duxapp'
 import { DuxuiIcon } from '../DuxuiIcon'
 import './index.scss'
@@ -47,7 +47,7 @@ export const DropDown = forwardRef(({
       return
     }
     view.current.measureInWindow?.((x, y, width, height) => {
-      const { statusBarHeight } = getSystemInfoSync()
+      const { statusBarHeight } = getWindowInfo()
       setPosition({ left: x, top: y + height + statusBarHeight, opacity: 0 })
       setShow(true)
     })

--- a/components/HorseLanternLottery/index.jsx
+++ b/components/HorseLanternLottery/index.jsx
@@ -1,6 +1,6 @@
 import { Layout, px } from '@/duxapp'
 import { useState, isValidElement, useCallback, useRef, useEffect } from 'react'
-import { getSystemInfoSync } from '@tarojs/taro'
+import { getWindowInfo } from '@tarojs/taro'
 import { Column, Row } from '../Flex'
 
 export const HorseLanternLottery = ({
@@ -158,4 +158,4 @@ const ItemSelf = ({ list, index, Item, select, ...props }) => {
   </Column>
 }
 
-const toPx = val => getSystemInfoSync().screenWidth / 750 * val
+const toPx = val => getWindowInfo().screenWidth / 750 * val

--- a/components/Interact/ShowMessage.jsx
+++ b/components/Interact/ShowMessage.jsx
@@ -1,7 +1,7 @@
 import { Text } from '@tarojs/components'
 import { useEffect, useRef, useState } from 'react'
 import { asyncTimeOut, route, Animated, nextTick, pxNum, currentPage, TopView } from '@/duxapp'
-import { getSystemInfoSync } from '@tarojs/taro'
+import { getWindowInfo } from '@tarojs/taro'
 import { BoxShadow } from '../BoxShadow'
 import './ShowMessage.scss'
 
@@ -13,7 +13,7 @@ const ShowMessage = ({
   onRemove
 }) => {
 
-  let { statusBarHeight = 0 } = getSystemInfoSync()
+  let { statusBarHeight = 0 } = getWindowInfo()
 
   if (!statusBarHeight) {
     statusBarHeight = 0

--- a/components/Menu/index.jsx
+++ b/components/Menu/index.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useState, createContext, useContext, useRef, forwardRef, useImperativeHandle, useMemo, useEffect } from 'react'
 import { Layout, Absolute, duxappTheme, Animated, nextTick, pxNum, asyncTimeOut, transformStyle, px } from '@/duxapp'
 import classNames from 'classnames'
-import { getSystemInfoSync } from '@tarojs/taro'
+import { getWindowInfo } from '@tarojs/taro'
 import { Column, Row } from '../Flex'
 import { Text } from '../Text'
 import { DuxuiIcon } from '../DuxuiIcon'
@@ -292,7 +292,7 @@ const PullContent = forwardRef(({
     }
   })
 
-  const screenHeight = getSystemInfoSync().screenHeight
+  const screenHeight = getWindowInfo().screenHeight
 
   return <Absolute>
     <Column

--- a/components/Sign/index.jsx
+++ b/components/Sign/index.jsx
@@ -1,5 +1,5 @@
 import { Component } from 'react'
-import { nextTick, createSelectorQuery, getSystemInfoSync, canvasToTempFilePath } from '@tarojs/taro'
+import { nextTick, createSelectorQuery, getWindowInfo, canvasToTempFilePath } from '@tarojs/taro'
 import { Canvas } from '@tarojs/components'
 import { Layout } from '@/duxapp'
 import classNames from 'classnames'
@@ -32,7 +32,7 @@ export class Sign extends Component {
             const ctx = canvas.getContext('2d')
 
             if (process.env.TARO_ENV !== 'h5') {
-              const dpr = getSystemInfoSync().pixelRatio
+              const dpr = getWindowInfo().pixelRatio
               canvas.width = _res[0].width * dpr
               canvas.height = _res[0].height * dpr
               ctx.scale(dpr, dpr)

--- a/components/Svg/components/Svg.jsx
+++ b/components/Svg/components/Svg.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useImperativeHandle, forwardRef, useCallback } from 'react'
 import { Canvas, View } from '@tarojs/components'
 import { CustomWrapper } from '@/duxapp'
-import { getSystemInfoSync, createSelectorQuery, canvasToTempFilePath } from '@tarojs/taro'
+import { getWindowInfo, createSelectorQuery, canvasToTempFilePath } from '@tarojs/taro'
 import { draw, useForwardEvent } from './Common'
 import { SvgComponent } from './SvgComponent'
 
@@ -86,7 +86,7 @@ export const Svg = forwardRef(({ children, width, height, ...props }, ref) => {
           const ctx = canvas.getContext('2d')
 
           if (process.env.TARO_ENV !== 'h5') {
-            const dpr = getSystemInfoSync().pixelRatio
+            const dpr = getWindowInfo().pixelRatio
             canvas.width = _res[0].width * dpr
             canvas.height = _res[0].height * dpr
             ctx.scale(dpr, dpr)


### PR DESCRIPTION
消除调试输出的警告：wx.getSystemInfoSync is deprecated.Please use wx.getSystemSetting/wx.getAppAuthorizeSetting/wx.getDeviceInfo/wx.getWindowInfo/wx.getAppBaseInfo instead.